### PR TITLE
Re-style the toolbar

### DIFF
--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -18,7 +18,7 @@ module DevToolbar
               position: fixed;
               right: 0;
               top: 50%;
-              transform: translateY(-50%) rotate(90deg);
+              transform: rotate(270deg);
               background: #333;
               color: #fff;
               padding: 0.5rem;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,13 +38,14 @@ module DevToolbar
             }
         
             #dev-toolbar-links {
+              display: flex;
               background: #fff;
-              color: #808080;
               padding: 0.5rem;
               border: 3px solid #666666;
               border-radius: 10px;
               justify-content: center;
               align-items: center;
+              gap: 10px;
             }
         
             #dev-toolbar-links.hidden {
@@ -53,7 +54,6 @@ module DevToolbar
         
             #dev-toolbar-links a {
               color: #808080;
-              margin-right: 10px;
             }
           </style>
           <script>

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -22,11 +22,12 @@ module DevToolbar
               color: #808080;
               padding: 0.5rem;
               z-index: 1000;
-              border: 3px solid #333333;
+              border: 3px solid #808080;
               border-radius: 10px;
             }
 
             #dev-toolbar a {
+              color: #808080;
               margin-right: 10px;
             }
           </style>

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -18,7 +18,7 @@ module DevToolbar
               position: fixed;
               right: 0;
               top: 50%;
-              transform: rotate(270deg);
+              transform: translateY(-50%) rotate(270deg);
               background: #333;
               color: #fff;
               padding: 0.5rem;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -11,29 +11,53 @@ module DevToolbar
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
-            #{toolbar_links}
+            <button id="dev-toolbar-toggle">🛠️</button>
+            <div id="dev-toolbar-links" class="hidden">
+              #{toolbar_links}
+            </div>
           </div>
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 1%;
+              right: 5%;
               bottom: 25%;
+              z-index: 1000;
+            }
+
+            #dev-toolbar-toggle {
+              font-size: 2em;
+              background: none;
+              border: none;
+              padding: 0;
+              cursor: pointer;
+            }
+
+            #dev-toolbar-links {
+              display: flex;
               background: #fff;
               color: #808080;
               padding: 0.5rem;
-              z-index: 1000;
               border: 3px solid #666666;
               border-radius: 10px;
-              display: flex;
               justify-content: center;
               align-items: center;
             }
 
-            #dev-toolbar a {
+            #dev-toolbar-links.hidden {
+              display: none;
+            }
+
+            #dev-toolbar-links a {
               color: #808080;
               margin-right: 10px;
             }
           </style>
+          <script>
+            document.getElementById('dev-toolbar-toggle').addEventListener('click', function() {
+              var links = document.getElementById('dev-toolbar-links');
+              links.classList.toggle('hidden');
+            });
+          </script>
         HTML
 
         response_body.sub!('</body>', "#{toolbar_html}</body>")

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -11,26 +11,32 @@ module DevToolbar
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
+            <div id="dev-toolbar-title">Development Links</div>
             #{toolbar_links}
           </div>
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 5%;
-              bottom: 5%;
+              right: 2%;
+              bottom: 2%;
               background: #fff;
               color: #000;
               padding: 0.5rem;
               z-index: 1000;
-              border: 3px solid red;
-              border-radius: 10px;
+              border: 0.2rem solid red;
+              border-radius: 0.6rem;
               font-weight: bold;
             }
       
             #dev-toolbar a {
               text-decoration: underline;
               color: #000;
-              margin-right: 10px;
+              margin-right: 0.6rem;
+            }
+
+            #dev-toolbar-title {
+              text-align: center;
+              font-weight: bold;
             }
           </style>
         HTML

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -11,7 +11,6 @@ module DevToolbar
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
-            <div id="dev-toolbar-title">AppDev Toolbar</div>
             #{toolbar_links}
           </div>
           <style>
@@ -19,22 +18,16 @@ module DevToolbar
               position: fixed;
               right: 10px;
               bottom: 10px;
-              background: white;
-              color: black;
+              background: #fff;
+              color: #808080;
               padding: 0.5rem;
               z-index: 1000;
-              border: 3px solid red;
+              border: 3px solid #333333;
               border-radius: 10px;
             }
 
             #dev-toolbar a {
-              color: black;
               margin-right: 10px;
-            }
-
-            #dev-toolbar-title {
-              text-align: center;
-              font-weight: bold;
             }
           </style>
         HTML

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -17,7 +17,8 @@ module DevToolbar
             #dev-toolbar {
               position: fixed;
               right: 0;
-              top: 0;
+              top: 50%;
+              transform: translateY(-50%) rotate(90deg);
               background: #333;
               color: #fff;
               padding: 0.5rem;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -12,7 +12,7 @@ module DevToolbar
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
             <div id="dev-toolbar-button">
-              <button id="dev-toolbar-toggle">🛠️</button>
+              <a id="dev-toolbar-toggle">🛠️</a>
             </div>
             <div id="dev-toolbar-links" class="hidden">
               #{toolbar_links}
@@ -21,40 +21,43 @@ module DevToolbar
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 5%;
-              bottom: 50%;
+              right: 0;
+              top: 50vh;
+              transform: translateY(-50%);
+              background-color: #f0f0f0;
+              border: 1px solid #ccc;
               z-index: 1000;
               display: flex;
               flex-direction: column;
               align-items: center;
+              font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+              color: #808080;
             }
         
             #dev-toolbar-toggle {
               font-size: 2em;
-              background: none;
               border: none;
-              padding: 0;
               cursor: pointer;
+              line-height: 1.5;
+              padding: 0 10px;
+              text-decoration: none;
             }
         
             #dev-toolbar-links {
               display: flex;
               flex-direction: column;
-              background: #fff;
-              padding: 0.5rem;
-              border: 3px solid #666666;
-              border-radius: 10px;
-              justify-content: center;
-              align-items: flex-start;
-              gap: 10px;
+            }
+
+            .dev-toolbar-link {
+              padding: 5px 10px;
+              border-bottom: 1px #f0f0f0 solid;
+              color: #808080;
+              text-decoration: none;
+              background-color: white;
             }
         
             #dev-toolbar-links.hidden {
               display: none;
-            }
-        
-            #dev-toolbar-links a {
-              color: #808080;
             }
           </style>
           <script>
@@ -78,7 +81,7 @@ module DevToolbar
 
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
-        "<a href='#{link[:path]}' target='_blank'>#{link[:name]}</a>"
+        "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
       end.join(' ')
     end
   end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -22,8 +22,11 @@ module DevToolbar
               color: #808080;
               padding: 0.5rem;
               z-index: 1000;
-              border: 3px solid #808080;
+              border: 3px solid #666666;
               border-radius: 10px;
+              display: flex;
+              justify-content: center;
+              align-items: center;
             }
 
             #dev-toolbar a {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -16,8 +16,8 @@ module DevToolbar
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 10px;
-              bottom: 10px;
+              right: 1%;
+              bottom: 25%;
               background: #fff;
               color: #808080;
               padding: 0.5rem;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -17,8 +17,7 @@ module DevToolbar
             #dev-toolbar {
               position: fixed;
               right: 0;
-              top: 50%;
-              transform: translateY(-50%) rotate(270deg);
+              top: 100%;
               background: #333;
               color: #fff;
               padding: 0.5rem;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -26,7 +26,7 @@ module DevToolbar
               border: 3px solid red;
               border-radius: 10px;
             }
-      
+
             #dev-toolbar a {
               color: black;
               margin-right: 10px;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -11,7 +11,9 @@ module DevToolbar
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
-            <button id="dev-toolbar-toggle">🛠️</button>
+            <div id="dev-toolbar-button">
+              <button id="dev-toolbar-toggle">🛠️</button>
+            </div>
             <div id="dev-toolbar-links" class="hidden">
               #{toolbar_links}
             </div>
@@ -22,8 +24,11 @@ module DevToolbar
               right: 5%;
               bottom: 25%;
               z-index: 1000;
+              display: flex;
+              flex-direction: column;
+              align-items: center;
             }
-
+        
             #dev-toolbar-toggle {
               font-size: 2em;
               background: none;
@@ -31,9 +36,8 @@ module DevToolbar
               padding: 0;
               cursor: pointer;
             }
-
+        
             #dev-toolbar-links {
-              display: flex;
               background: #fff;
               color: #808080;
               padding: 0.5rem;
@@ -42,11 +46,11 @@ module DevToolbar
               justify-content: center;
               align-items: center;
             }
-
+        
             #dev-toolbar-links.hidden {
               display: none;
             }
-
+        
             #dev-toolbar-links a {
               color: #808080;
               margin-right: 10px;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -16,8 +16,8 @@ module DevToolbar
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 0;
-              bottom: 0;
+              right: 5%;
+              bottom: 5%;
               background: #fff;
               color: #000;
               padding: 0.5rem;
@@ -28,8 +28,9 @@ module DevToolbar
             }
       
             #dev-toolbar a {
-              text-decoration: none;
+              text-decoration: underline;
               color: #000;
+              margin-right: 10px;
             }
           </style>
         HTML

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -22,7 +22,7 @@ module DevToolbar
             #dev-toolbar {
               position: fixed;
               right: 5%;
-              bottom: 25%;
+              bottom: 50%;
               z-index: 1000;
               display: flex;
               flex-direction: column;
@@ -39,12 +39,13 @@ module DevToolbar
         
             #dev-toolbar-links {
               display: flex;
+              flex-direction: column;
               background: #fff;
               padding: 0.5rem;
               border: 3px solid #666666;
               border-radius: 10px;
               justify-content: center;
-              align-items: center;
+              align-items: flex-start;
               gap: 10px;
             }
         

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -25,11 +25,9 @@ module DevToolbar
               z-index: 1000;
               border: 0.2rem solid red;
               border-radius: 0.6rem;
-              font-weight: bold;
             }
       
             #dev-toolbar a {
-              text-decoration: underline;
               color: #000;
               margin-right: 0.6rem;
             }

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -17,16 +17,19 @@ module DevToolbar
             #dev-toolbar {
               position: fixed;
               right: 0;
-              top: 100%;
-              background: #333;
-              color: #fff;
+              bottom: 0;
+              background: #fff;
+              color: #000;
               padding: 0.5rem;
               z-index: 1000;
+              border: 3px solid red;
+              border-radius: 10px;
+              font-weight: bold;
             }
-
+      
             #dev-toolbar a {
-              color: #fff;
-              margin-right: 0.5rem;
+              text-decoration: none;
+              color: #000;
             }
           </style>
         HTML

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -11,25 +11,25 @@ module DevToolbar
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
-            <div id="dev-toolbar-title">Development Links</div>
+            <div id="dev-toolbar-title">AppDev Toolbar</div>
             #{toolbar_links}
           </div>
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 2%;
-              bottom: 2%;
-              background: #fff;
-              color: #000;
+              right: 10px;
+              bottom: 10px;
+              background: white;
+              color: black;
               padding: 0.5rem;
               z-index: 1000;
-              border: 0.2rem solid red;
-              border-radius: 0.6rem;
+              border: 3px solid red;
+              border-radius: 10px;
             }
       
             #dev-toolbar a {
-              color: #000;
-              margin-right: 0.6rem;
+              color: black;
+              margin-right: 10px;
             }
 
             #dev-toolbar-title {

--- a/lib/dev_toolbar/version.rb
+++ b/lib/dev_toolbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevToolbar
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Resolves https://github.com/firstdraft/dev_toolbar/issues/4

## Problem

Prior to this PR, the toolbar links were unstyled and stickied to the top right corner which got in the way of navigation.

## Solution

### Things I tried but didn't like

- Rotating the links and putting them on the right-middle was both in the way and difficult to read.
- The difficult to read part might be solved by using icons instead of named links. However this requires us to: 1) decide on a good icon for each link; 2) make sure that font-awesome is available in all the projects since the current dev_toolbar gem just injects a div into the `body`; 3) potentially confuse students with non-obvious icons, where a simple named link might be more descriptive

### What I settled on

The bottom right corner is a good place for the links (I think) and by adding just a little bit more styling, they don't look bad and are fairly obvious in meaning:

![image](https://github.com/firstdraft/dev_toolbar/assets/12408296/ee63151c-06a9-4223-a1f6-1b8340fee41c)

## How to test

In an existing project add:

```rb
group :development do
  gem "dev_toolbar", git: "https://github.com/firstdraft/dev_toolbar.git", branch: "bp-styling"
end
```

And then add a `config/initializers/dev_toolbar.rb` file with the contents:

```rb
DevToolbar.configure do |config|
  config.links = [
    { name: "Routes", path: "/rails/info/routes" },
    { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
    { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder
    # etc.
  ]
end
```

Note that the _naming_ of the links and addition of more links is configurable within a given project using that initializer. I.e., the gem itself makes no decisions about what links are shown or what they are named. Only the title "AppDev Toolbar" was added into the gem itself, as this seemed like a universal decision that we can make here.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4031825bf9d698ac970dabe0f89eae2ae62cac22  | 
|--------|--------|

### Summary:
This PR updates the DevToolbar to version 1.1.0, enhancing its styling, usability, and user interaction, with specific updates to middleware and CSS for simplicity and improved aesthetics, including a new feature to toggle visibility.

**Key points**:
- Resolves https://github.com/firstdraft/dev_toolbar/issues/4
- Update `DevToolbar` version from `1.0.0` to `1.1.0` in `lib/dev_toolbar/version.rb`
- Enhanced toolbar styling and repositioned links for better usability
- Configurable link naming and addition within projects
- Updated styling for `DevToolbar` in `lib/dev_toolbar/middleware.rb`
- Repositioned toolbar to bottom right
- Enhanced CSS for better visibility and aesthetics
- Discarded complex changes for simplicity and clarity
- Removed toolbar title for a cleaner interface
- Toolbar links are dynamically generated and injected only in development environment for HTML content types
- Updated `lib/dev_toolbar/middleware.rb` to enhance toolbar styling and positioning
- Toolbar fixed to bottom right with improved CSS for visibility and aesthetics
- Links within toolbar are dynamically generated and configurable
- Changes aim to make toolbar less intrusive and more user-friendly
- Enhance user experience by making toolbar less intrusive and more visually appealing
- Enhance `DevToolbar` styling and positioning in `lib/dev_toolbar/middleware.rb`
- Improve CSS for better visibility and aesthetics
- Toggle visibility with a button, enhancing user interaction
- Style links within the toolbar for better readability


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->