### PR TITLE
Some styling tweaks

### DIFF
--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,6 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
+              padding: 5px 10px;
             }
         
             #dev-toolbar-links {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              padding: 10px;
+              padding: 5px 10px;
             }
         
             #dev-toolbar-links {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -25,40 +25,30 @@ module DevToolbar
               top: 50vh;
               transform: translateY(-50%);
               background-color: #f0f0f0;
-              padding: 10px;
               border: 1px solid #ccc;
               z-index: 1000;
               display: flex;
               flex-direction: column;
-              align-items: center;
+              font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+              color: #808080;
             }
         
             #dev-toolbar-toggle {
               font-size: 2em;
-              background: none;
-              border: none;
-              padding: 0;
-              cursor: pointer;
             }
         
             #dev-toolbar-links {
               display: flex;
               flex-direction: column;
-              background: #fff;
-              padding: 0.5rem;
-              border: 3px solid #666666;
-              border-radius: 10px;
-              justify-content: center;
-              align-items: flex-start;
-              gap: 10px;
+            }
+
+            .dev-toolbar-link {
+              padding: 3px 5px;
+              border-bottom: 1px #f0f0f0 solid;
             }
         
             #dev-toolbar-links.hidden {
               display: none;
-            }
-        
-            #dev-toolbar-links a {
-              color: #808080;
             }
           </style>
           <script>
@@ -83,7 +73,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         "<a href='#{link[:path]}' target='_blank'>#{link[:name]}</a>"
-      end.join(' ')
+      end.join('\n')
     end
   end
 end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -37,6 +37,7 @@ module DevToolbar
             #dev-toolbar-toggle {
               font-size: 2em;
               border: none;
+              cursor: pointer;
             }
         
             #dev-toolbar-links {
@@ -45,7 +46,7 @@ module DevToolbar
             }
 
             .dev-toolbar-link {
-              padding: 3px 5px;
+              padding: 5px 10px;
               border-bottom: 1px #f0f0f0 solid;
               color: #808080;
               text-decoration: none;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -12,7 +12,7 @@ module DevToolbar
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
             <div id="dev-toolbar-button">
-              <div id="dev-toolbar-toggle">🛠️</div>
+              <a id="dev-toolbar-toggle">🛠️</a>
             </div>
             <div id="dev-toolbar-links" class="hidden">
               #{toolbar_links}
@@ -39,6 +39,7 @@ module DevToolbar
               border: none;
               cursor: pointer;
               padding: 5px 10px;
+              text-decoration: none;
             }
         
             #dev-toolbar-links {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              padding: 8px 10px;
+              padding: 10px;
               text-decoration: none;
             }
         

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,8 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              line-height: 2;
+              line-height: 1.5;
+              padding: 0 10px;
               text-decoration: none;
             }
         

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -29,6 +29,7 @@ module DevToolbar
               z-index: 1000;
               display: flex;
               flex-direction: column;
+              align-items: center;
               font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
               color: #808080;
             }
@@ -46,6 +47,9 @@ module DevToolbar
             .dev-toolbar-link {
               padding: 3px 5px;
               border-bottom: 1px #f0f0f0 solid;
+              color: #808080;
+              text-decoration: none;
+              background-color: white;
             }
         
             #dev-toolbar-links.hidden {
@@ -74,7 +78,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
-      end.join('\n')
+      end.join(' ')
     end
   end
 end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -35,6 +35,7 @@ module DevToolbar
         
             #dev-toolbar-toggle {
               font-size: 2em;
+              border: none;
             }
         
             #dev-toolbar-links {
@@ -72,7 +73,7 @@ module DevToolbar
 
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
-        "<a href='#{link[:path]}' target='_blank'>#{link[:name]}</a>"
+        "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
       end.join('\n')
     end
   end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              padding: 5px 10px;
+              padding: 8px 10px;
               text-decoration: none;
             }
         

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -12,7 +12,7 @@ module DevToolbar
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
             <div id="dev-toolbar-button">
-              <button id="dev-toolbar-toggle">🛠️</button>
+              <div id="dev-toolbar-toggle">🛠️</div>
             </div>
             <div id="dev-toolbar-links" class="hidden">
               #{toolbar_links}

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -21,8 +21,12 @@ module DevToolbar
           <style>
             #dev-toolbar {
               position: fixed;
-              right: 5%;
-              bottom: 50%;
+              right: 0;
+              top: 50vh;
+              transform: translateY(-50%);
+              background-color: #f0f0f0;
+              padding: 10px;
+              border: 1px solid #ccc;
               z-index: 1000;
               display: flex;
               flex-direction: column;

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              padding: 5px 10px;
+              padding: 10px;
             }
         
             #dev-toolbar-links {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -38,7 +38,7 @@ module DevToolbar
               font-size: 2em;
               border: none;
               cursor: pointer;
-              padding: 10px;
+              line-height: 2;
               text-decoration: none;
             }
         


### PR DESCRIPTION
- Use `vh` instead of `%` so that it is in the middle even when the body is small:
<img width="1624" alt="Screenshot 2024-06-10 at 9 58 05 PM" src="https://github.com/firstdraft/dev_toolbar/assets/811217/b4ee5d0f-7e14-4f65-aa5d-90cc20c4cd92">

- Use system font stack.
- Some whitespace and border tweaks.
- Don't use button because it could be styled by something else, e.g. it looks weird on /rails/db

End result:

<img width="1624" alt="Screenshot 2024-06-10 at 10 18 01 PM" src="https://github.com/firstdraft/dev_toolbar/assets/811217/1e46e319-c56d-4eca-9a2b-14ccaa899afd">


<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9b83d05cd78d4a68a987d2212575fa976a88f2b5  | 
|--------|--------|

### Summary:
Enhanced the DevToolbar's styling and functionality, including vertical centering, system fonts, toggleable links, and updated the version to 1.1.0, with additional UI consistency improvements.

**Key points**:
- Updated `lib/dev_toolbar/middleware.rb` for styling and functionality improvements.
- Changed toolbar positioning to `50vh` with `transform: translateY(-50%)` for vertical centering.
- Implemented system font stack and adjusted text, background colors, and padding for buttons.
- Added toggle functionality for toolbar links with JavaScript.
- Bumped version in `lib/dev_toolbar/version.rb` to `1.1.0`.
- Some whitespace and border tweaks.
- Updated vertical centering using `vh` in `lib/dev_toolbar/middleware.rb`.
- Changed padding for `#dev-toolbar-toggle` from `5px 10px` to `8px 10px`.
- Adjusted `#dev-toolbar-toggle` padding and line-height in `lib/dev_toolbar/middleware.rb`.
- Enhanced UI consistency across different environments.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->