### PR TITLE
Add view source button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, add a configuration file with the names and routes you want links for:
 # config/initializers/dev_toolbar.rb
 DevToolbar.configure do |config|
   config.links = [
-    { name: "View Source", path: "/to-do" },
+    { name: "View Source" },
     { name: "Routes", path: "/rails/info/routes" },
     { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
     { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then, add a configuration file with the names and routes you want links for:
 # config/initializers/dev_toolbar.rb
 DevToolbar.configure do |config|
   config.links = [
+    { name: "View Source", path: "/to-do" },
     { name: "Routes", path: "/rails/info/routes" },
     { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
     { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,7 +82,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         if link[:name] == "View Source"
-          "<a href='view-source:' class='dev-toolbar-link'>#{link[:name]}</a>"
+          "<a href='#' onclick='window.open(\"view-source:\" + window.location.href); return false;' class='dev-toolbar-link'>#{link[:name]}</a>"
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -8,7 +8,6 @@ module DevToolbar
       status, headers, response = @app.call(env)
 
       if Rails.env.development? && headers["Content-Type"]&.include?("text/html")
-        request = Rack::Request.new(env)
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
@@ -16,7 +15,7 @@ module DevToolbar
               <a id="dev-toolbar-toggle">🛠️</a>
             </div>
             <div id="dev-toolbar-links" class="hidden">
-              #{toolbar_links(request)}
+              #{toolbar_links}
             </div>
           </div>
           <style>
@@ -82,8 +81,11 @@ module DevToolbar
 
     def toolbar_links(request)
       DevToolbar.configuration.links.map do |link|
-        href = link[:name] == "View Source" ? "view-source:#{request.base_url}" : link[:path]
-        "<a href='#{href}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
+        if link[:name] == "View Source"
+          "<a href='#' onclick='window.open(\"view-source:\" + window.location.href); return false;' class='dev-toolbar-link'>#{link[:name]}</a>"
+        else
+          "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
+        end
       end.join(' ')
     end
   end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -8,6 +8,7 @@ module DevToolbar
       status, headers, response = @app.call(env)
 
       if Rails.env.development? && headers["Content-Type"]&.include?("text/html")
+        request = Rack::Request.new(env)
         response_body = response.body
         toolbar_html = <<-HTML
           <div id="dev-toolbar">
@@ -15,7 +16,7 @@ module DevToolbar
               <a id="dev-toolbar-toggle">🛠️</a>
             </div>
             <div id="dev-toolbar-links" class="hidden">
-              #{toolbar_links}
+              #{toolbar_links(request)}
             </div>
           </div>
           <style>
@@ -79,9 +80,10 @@ module DevToolbar
 
     private
 
-    def toolbar_links
+    def toolbar_links(request)
       DevToolbar.configuration.links.map do |link|
-        "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
+        href = link[:name] == "View Source" ? "view-source:#{request.base_url}" : link[:path]
+        "<a href='#{href}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
       end.join(' ')
     end
   end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -79,7 +79,7 @@ module DevToolbar
 
     private
 
-    def toolbar_links(request)
+    def toolbar_links
       DevToolbar.configuration.links.map do |link|
         if link[:name] == "View Source"
           "<a href='#' onclick='window.open(\"view-source:\" + window.location.href); return false;' class='dev-toolbar-link'>#{link[:name]}</a>"

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,7 +82,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         if link[:name] == "View Source"
-          "<a href='#' onclick='window.open(\"view-source:\" + window.location.href); return false;' class='dev-toolbar-link'>#{link[:name]}</a>"
+          "<a href='view-source:' class='dev-toolbar-link'>#{link[:name]}</a>"
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end


### PR DESCRIPTION
Resolves #9 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a "View Source" button to the development toolbar, allowing users to view the source code of the current page.
> 
>   - **Behavior**:
>     - Adds "View Source" button to the development toolbar in `middleware.rb`.
>     - Uses `view-source:` URL scheme to open the source code of the current page.
>   - **Configuration**:
>     - Updates `README.md` to include "View Source" link in configuration example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fdev_toolbar&utm_source=github&utm_medium=referral)<sup> for 52a8103f1e959c2297c7da8dffa69b6ac4655e71. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->