### PR TITLE
Skip erd link if none present

### DIFF
--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -83,7 +83,7 @@ module DevToolbar
       DevToolbar.configuration.links.map do |link|
         # if the erd.png file does not exist in /public, don't show the link
         if link[:name] == "Data Model" && !File.exist?(Rails.public_path.join("erd.png"))
-          ""
+          next
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -87,7 +87,7 @@ module DevToolbar
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end
-      end.join(' ')
+      end.compact.join(" ")
     end
   end
 end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -81,7 +81,12 @@ module DevToolbar
 
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
-        "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
+        # if the erd.png file does not exist in /public, don't show the link
+        if link[:name] == "Data Model" && !File.exist?(Rails.public_path.join("erd.png"))
+          ""
+        else
+          "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
+        end
       end.join(' ')
     end
   end

--- a/lib/dev_toolbar/version.rb
+++ b/lib/dev_toolbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevToolbar
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
If there is no ERD, skip adding the link to it. There is a separate issue #6 where we want to perhaps find a better solution for presenting the ERD, but for now, we could use a fix to prevent a 404 on the link if no ERD is present.

We could just skip adding the `/erd.png` link in the initializer, but that requires us to remember and check that always. A better solution is to handle it in the gem in case we forget to remove it from the initializer. Then we can use a uniform initializer across all of our Rails projects and not need to have different configurations for different projects and have to keep them all up to date.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Skip "Data Model" link in `toolbar_links` if `erd.png` is missing, and update version to `1.2.0`.
> 
>   - **Behavior**:
>     - In `middleware.rb`, `toolbar_links` method skips "Data Model" link if `erd.png` is missing in `/public`.
>   - **Misc**:
>     - Adds a conditional check for file existence before rendering the link.
>     - Updates version to `1.2.0` in `version.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fdev_toolbar&utm_source=github&utm_medium=referral)<sup> for b22347ec061b2b850503eca4d20cfea6c6896e11. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->