### PR TITLE
Instructions to wrap initializer in development check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ Then, add a configuration file with the names and routes you want links for:
 
 ```rb
 # config/initializers/dev_toolbar.rb
-DevToolbar.configure do |config|
-  config.links = [
-    { name: "Routes", path: "/rails/info/routes" },
-    { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-    { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder
-    # etc.
-  ]
+
+if Rails.env.development?
+  DevToolbar.configure do |config|
+    config.links = [
+      { name: "Routes", path: "/rails/info/routes" },
+      { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
+      { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder
+      # etc.
+    ]
+  end
 end
 ```
 


### PR DESCRIPTION
I noticed that for our Rails projects which all have this line in the `bin/setup` script:

```
bundle exec rake db:create RAILS_ENV=test
```

setup fails with this error when the `config/initializers/dev_toolbar.rb` is not wrapped in a development environment check:

```
== Creating test database ==
rake aborted!
NameError: uninitialized constant DevToolbar (NameError)

DevToolbar.configure do |config|
^^^^^^^^^^
/Users/ben/Desktop/firstdraft-github/orgs/appdev-projects/phase1/rails-rps/config/initializers/dev_toolbar.rb:1:in `<main>'
/Users/ben/Desktop/firstdraft-github/orgs/appdev-projects/phase1/rails-rps/config/environment.rb:5:in `<main>'
<internal:/Users/ben/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/Users/ben/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/Users/ben/.rbenv/versions/3.2.1/bin/bundle:25:in `load'
/Users/ben/.rbenv/versions/3.2.1/bin/bundle:25:in `<main>'
Tasks: TOP => db:create => db:load_config => environment
(See full trace by running task with --trace)

== Command ["bundle exec rake db:create RAILS_ENV=test"] failed ==
```

That surprised me given this code in the gem:

https://github.com/firstdraft/dev_toolbar/blob/4acbc33a0dcdb57985af51ca9a4cd58b23fc491e/lib/dev_toolbar/middleware.rb#L10

---

Perhaps there is a better solution than just updating the README to point out this requirement, however, on #8, there is already planned work to create a generator for the initializer. During that work, we can investigate this more deeply, but for now, since we need this working ASAP for class, I think we just need this instruction in the README and to have all the initializers use this slight hack.

Since all initializers will be uniform across our Rails projects and managed with the [project-syncing tool](https://github.com/firstdraft/project-syncing), it will be easy to fix this later on across the projects that are using the `dev_toolbar` gem.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wraps `DevToolbar.configure` in a development check to prevent test database creation errors, updating `README.md` accordingly.
> 
>   - **Behavior**:
>     - Wraps `DevToolbar.configure` in `config/initializers/dev_toolbar.rb` with `if Rails.env.development?` to prevent errors during test database creation.
>   - **Documentation**:
>     - Updates `README.md` to include the development environment check in the configuration example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fdev_toolbar&utm_source=github&utm_medium=referral)<sup> for f47a9f20f97903970d1cac916ab4d83d548e3268. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->