### PR TITLE
Build a page with instructions for ERD generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if Rails.env.development?
     config.links = [
       { name: "Routes", path: "/rails/info/routes" },
       { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-      { name: "ERD", path: "/erd" }, # to display this, the erd.png must be in the root folder
+      { name: "ERD", path: "/erd" }, # erd.png must be in the root folder
       # etc.
     ]
   end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if Rails.env.development?
     config.links = [
       { name: "Routes", path: "/rails/info/routes" },
       { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-      { name: "ERD", path: "/erd" }, # to display this, the erd.png must be in the public/ folder
+      { name: "ERD", path: "/erd" }, # to display this, the erd.png must be in the root folder
       # etc.
     ]
   end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if Rails.env.development?
     config.links = [
       { name: "Routes", path: "/rails/info/routes" },
       { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-      { name: "Data Model", path: "/erd.png" }, # erd.png must be in public/ folder
+      { name: "ERD", path: "/erd.png" }, # erd.png must be in public/ folder
       # etc.
     ]
   end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if Rails.env.development?
     config.links = [
       { name: "Routes", path: "/rails/info/routes" },
       { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-      { name: "ERD", path: "/erd" }, # erd.png must be in public/ folder
+      { name: "ERD", path: "/erd" }, # to display this, the erd.png must be in the public/ folder
       # etc.
     ]
   end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if Rails.env.development?
     config.links = [
       { name: "Routes", path: "/rails/info/routes" },
       { name: "Database", path: "/rails/db" }, # rails_db gem must be installed
-      { name: "ERD", path: "/erd.png" }, # erd.png must be in public/ folder
+      { name: "ERD", path: "/erd" }, # erd.png must be in public/ folder
       # etc.
     ]
   end

--- a/lib/dev_toolbar.rb
+++ b/lib/dev_toolbar.rb
@@ -4,6 +4,7 @@ require_relative "dev_toolbar/version"
 require_relative "dev_toolbar/railtie"
 require_relative "dev_toolbar/middleware"
 require_relative "dev_toolbar/configuration"
+require_relative "dev_toolbar/engine"
 
 module DevToolbar
   class Error < StandardError; end

--- a/lib/dev_toolbar/app/controllers/dev_toolbar/erd_controller.rb
+++ b/lib/dev_toolbar/app/controllers/dev_toolbar/erd_controller.rb
@@ -1,0 +1,10 @@
+module DevToolbar
+  class ErdController < ActionController::Base
+    layout false
+    
+    def show
+      @erd_path = Rails.root.join("erd.png")
+      render :show
+    end
+  end
+end

--- a/lib/dev_toolbar/app/views/dev_toolbar/erd/show.html.erb
+++ b/lib/dev_toolbar/app/views/dev_toolbar/erd/show.html.erb
@@ -33,7 +33,7 @@
       <% if File.exist?(@erd_path) %>
         <img src="data:image/png;base64,<%= Base64.strict_encode64(File.read(@erd_path)) %>" alt="Entity Relationship Diagram">
       <% else %>
-        <p>Entity Relationship Diagram not found.</p>
+        <p>Entity Relationship Diagram not found. If this project has a database, you can generate the ERD with the command above.</p>
       <% end %>
     </div>
   </body>

--- a/lib/dev_toolbar/app/views/dev_toolbar/erd/show.html.erb
+++ b/lib/dev_toolbar/app/views/dev_toolbar/erd/show.html.erb
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Entity Relationship Diagram</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    
+    <style>
+      body {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+        text-align: center;
+        font-family: arial, sans-serif;
+        line-height: 1.5em;
+        color: #808080;
+      }
+
+      img {
+        max-width: 100%;
+        height: auto;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Entity Relationship Diagram</h1>
+    <p>To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command:</p>
+    <div>
+      <code>rake erd</code>
+    </div>
+    <p>Then refresh this page.</p>
+    <div>
+      <% if File.exist?(@erd_path) %>
+        <img src="data:image/png;base64,<%= Base64.strict_encode64(File.read(@erd_path)) %>" alt="Entity Relationship Diagram">
+      <% else %>
+        <p>Entity Relationship Diagram not found.</p>
+      <% end %>
+    </div>
+  </body>
+</html>

--- a/lib/dev_toolbar/engine.rb
+++ b/lib/dev_toolbar/engine.rb
@@ -1,6 +1,12 @@
 module DevToolbar
   class Engine < ::Rails::Engine
     isolate_namespace DevToolbar
+    
+    initializer "dev_toolbar.routes", after: :load_config_initializers do
+      Rails.application.routes.append do
+        mount DevToolbar::Engine, at: "/"
+      end
+    end
 
     routes.draw do
       get "/erd", to: "erd#show"

--- a/lib/dev_toolbar/engine.rb
+++ b/lib/dev_toolbar/engine.rb
@@ -2,14 +2,10 @@ module DevToolbar
   class Engine < ::Rails::Engine
     isolate_namespace DevToolbar
     
-    initializer "dev_toolbar.routes", after: :load_config_initializers do
-      Rails.application.routes.append do
-        mount DevToolbar::Engine, at: "/"
+    initializer "dev_toolbar.add_routes", after: :add_routing_paths do |app|
+      app.routes.append do
+        get "/erd", to: "dev_toolbar/erd#show"
       end
-    end
-
-    routes.draw do
-      get "/erd", to: "erd#show"
     end
   end
 end

--- a/lib/dev_toolbar/engine.rb
+++ b/lib/dev_toolbar/engine.rb
@@ -1,0 +1,9 @@
+module DevToolbar
+  class Engine < ::Rails::Engine
+    isolate_namespace DevToolbar
+
+    routes.draw do
+      get "/erd", to: "erd#show"
+    end
+  end
+end

--- a/lib/dev_toolbar/engine.rb
+++ b/lib/dev_toolbar/engine.rb
@@ -3,6 +3,7 @@ module DevToolbar
     isolate_namespace DevToolbar
 
     config.autoload_paths << File.expand_path("../app/controllers", __FILE__)
+    config.paths["app/views"] << File.expand_path("../app/views", __FILE__)
     
     initializer "dev_toolbar.add_routes", after: :add_routing_paths do |app|
       app.routes.append do

--- a/lib/dev_toolbar/engine.rb
+++ b/lib/dev_toolbar/engine.rb
@@ -1,6 +1,8 @@
 module DevToolbar
   class Engine < ::Rails::Engine
     isolate_namespace DevToolbar
+
+    config.autoload_paths << File.expand_path("../app/controllers", __FILE__)
     
     initializer "dev_toolbar.add_routes", after: :add_routing_paths do |app|
       app.routes.append do

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,7 +82,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         # if the erd.png file does not exist in /public, don't show the link
-        if link[:name] == "Data Model" && !File.exist?(Rails.public_path.join("erd.png"))
+        if link[:name] == "ERD" && !File.exist?(Rails.public_path.join("erd.png"))
           next
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,7 +82,27 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         # if the erd.png file does not exist in /public, don't show the link
-        if link[:name] == "ERD" && !File.exist?(Rails.public_path.join("erd.png"))
+        if link[:name] == "ERD"
+          if File.exist?(Rails.public_path.join("erd.png"))
+            erd_html = <<-HTML
+              <!DOCTYPE html>
+              <html>
+                <head><title>Entity Relationship Diagram</title></head>
+                <body style="text-align: center;">
+                  <h1>Entity Relationship Diagram</h1>
+                  <p>To update this diagram after database changes, run:</p>
+                  <pre style="background: #f0f0f0; padding: 10px; display: inline-block;">
+                    rake erd
+                  </pre>
+                  <div>
+                    <img src="/erd.png" style="max-width: 100%; margin-top: 20px;">
+                  </div>
+                </body>
+              </html>
+            HTML
+            
+            File.write(Rails.public_path.join("erd.html"), erd_html)
+            "<a href='/erd.html' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
           next
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -103,7 +103,9 @@ module DevToolbar
             
             File.write(Rails.public_path.join("erd.html"), erd_html)
             "<a href='/erd.html' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
-          next
+          else
+            next
+          end
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -95,7 +95,7 @@ module DevToolbar
                     Entity Relationship Diagram
                   </h1>
                   <p>
-                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <pre>rake erd</pre>
+                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <pre>rake erd</pre>, then close this page and reopen it from the toolbar link.
                   </p>
                   <div>
                     <img id="erd-image" src="/erd.png">

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -95,7 +95,7 @@ module DevToolbar
                     Entity Relationship Diagram
                   </h1>
                   <p>
-                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <pre>rake erd</pre>, then close this page and reopen it from the toolbar link.
+                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <code>rake erd</code>, then close this page and reopen it from the toolbar link.
                   </p>
                   <div>
                     <img id="erd-image" src="/erd.png">
@@ -104,7 +104,8 @@ module DevToolbar
               </html>
               <style>
                 body {
-                  text-align: center;
+                  display: flex;
+                  align-items: center;
                   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
                   color: #808080;
                 }

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,41 +82,8 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         # if the erd.png file does not exist in /public, don't show the link
-        if link[:name] == "ERD"
-          if File.exist?(Rails.public_path.join("erd.png"))
-            erd_html = <<-HTML
-              <!DOCTYPE html>
-              <html>
-                <head>
-                  <title>Entity Relationship Diagram</title>
-                </head>
-                <body>
-                  <h1>
-                    Entity Relationship Diagram
-                  </h1>
-                  <p>
-                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <code>rake erd</code>, then close this page and reopen it from the toolbar link.
-                  </p>
-                  <div>
-                    <img id="erd-image" src="/erd.png">
-                  </div>
-                </body>
-              </html>
-              <style>
-                body {
-                  display: flex;
-                  align-items: center;
-                  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
-                  color: #808080;
-                }
-              </style>
-            HTML
-            
-            File.write(Rails.public_path.join("erd.html"), erd_html)
-            "<a href='/erd.html' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
-          else
-            next
-          end
+        if link[:name] == "ERD" && !File.exist?(Rails.public_path.join("erd.png"))
+          next
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"
         end

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -95,7 +95,7 @@ module DevToolbar
                     Entity Relationship Diagram
                   </h1>
                   <p>
-                    To update this diagram after changes to your database or models, open a terminal and run: <pre id="instructions">rake erd</pre>
+                    To update this diagram after changes to your database or models (e.g. adding association accessors), open a terminal and run the command: <pre>rake erd</pre>
                   </p>
                   <div>
                     <img id="erd-image" src="/erd.png">

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -87,18 +87,41 @@ module DevToolbar
             erd_html = <<-HTML
               <!DOCTYPE html>
               <html>
-                <head><title>Entity Relationship Diagram</title></head>
-                <body style="text-align: center;">
-                  <h1>Entity Relationship Diagram</h1>
-                  <p>To update this diagram after database changes, run:</p>
-                  <pre style="background: #f0f0f0; padding: 10px; display: inline-block;">
+                <head>
+                  <title>Entity Relationship Diagram</title>
+                </head>
+                <body>
+                  <h1>
+                    Entity Relationship Diagram
+                  </h1>
+                  <p>
+                    To update this diagram after changes to your database or models, run:
+                  </p>
+                  <pre id="instructions">
                     rake erd
                   </pre>
                   <div>
-                    <img src="/erd.png" style="max-width: 100%; margin-top: 20px;">
+                    <img id="erd-image" src="/erd.png">
                   </div>
                 </body>
               </html>
+              <style>
+                body {
+                  text-align: center;
+                  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
+                  color: #808080;
+                }
+
+                #instructions {
+                  padding: 10px;
+                  display: flex;
+                }
+
+                #erd-image {
+                  max-width: 100%;
+                  margin-top: 20px;
+                }
+              </style>
             HTML
             
             File.write(Rails.public_path.join("erd.html"), erd_html)

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -95,11 +95,8 @@ module DevToolbar
                     Entity Relationship Diagram
                   </h1>
                   <p>
-                    To update this diagram after changes to your database or models, run:
+                    To update this diagram after changes to your database or models, open a terminal and run: <pre id="instructions">rake erd</pre>
                   </p>
-                  <pre id="instructions">
-                    rake erd
-                  </pre>
                   <div>
                     <img id="erd-image" src="/erd.png">
                   </div>
@@ -110,11 +107,6 @@ module DevToolbar
                   text-align: center;
                   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
                   color: #808080;
-                }
-
-                #instructions {
-                  padding: 10px;
-                  display: flex;
                 }
 
                 #erd-image {

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -109,11 +109,6 @@ module DevToolbar
                   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
                   color: #808080;
                 }
-
-                #erd-image {
-                  max-width: 100%;
-                  margin-top: 20px;
-                }
               </style>
             HTML
             

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -82,7 +82,7 @@ module DevToolbar
     def toolbar_links
       DevToolbar.configuration.links.map do |link|
         # if the erd.png file does not exist in /public, don't show the link
-        if link[:name] == "ERD" && !File.exist?(Rails.public_path.join("erd.png"))
+        if link[:name] == "ERD" && !File.exist?(Rails.root.join("erd.png"))
           next
         else
           "<a href='#{link[:path]}' target='_blank' class='dev-toolbar-link'>#{link[:name]}</a>"

--- a/lib/dev_toolbar/version.rb
+++ b/lib/dev_toolbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevToolbar
-  VERSION = "1.3.0"
+  VERSION = "2.0.0"
 end

--- a/lib/dev_toolbar/version.rb
+++ b/lib/dev_toolbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevToolbar
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Related to https://github.com/firstdraft/appdev/issues/633

Resolves #6 

## Problem

The ERD shown at the dev_toolbar link should be synced with the project database. Because resyncing requires running `rake erd`, we need some instructions for regenerating the data model. Also, we should not host the erd in the public folder since that makes it accessible on prduction.

## Solution

Create an engine and RCAV with instructions for running `rake erd` and showing the `erd.png` file at the root path. Separately, on https://github.com/firstdraft/project-syncing/pull/19, the gem version is bumped and the `bundle exec rails g erd:install` was run to add the auto generating of the ERD to any `rake db:` task (i.e., there will be no need to `rake erd` following a `rake db:migrate`).


## Testing

To test, open an appdev-projects repository in a codespace (use this one: https://github.com/appdev-projects/msm-queries), and change the `dev_toolbar` line in the Gemfile to:

```rb
gem "dev_toolbar", github: "firstdraft/dev_toolbar", branch: "bp-build-a-page-for-erd"
```

Then `bundle install` and start up the server. Run `bundle exec rails g erd:install` to create the auto generator that will run on `rake db:migrate`. (This will be added to all projects following the updates here on https://github.com/firstdraft/project-syncing/pull/19)

Create some models with the commands in [this lesson](https://learn.firstdraft.com/lessons/126-msm-queries) and `rake db:migrate` to see the new ERD link in the DevToolbar. 

Add an association and `rake erd` then refresh the `/erd` route to see the update.

![new-devtoolbar](https://github.com/user-attachments/assets/fa0f9df3-e9fc-4c49-a4e0-9cf1f99f405e)


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds ERD generation instructions and updates DevToolbar to conditionally display ERD link.
> 
>   - **Behavior**:
>     - Renames "Data Model" link to "ERD" in `README.md` and `middleware.rb`.
>     - Adds `ErdController` in `erd_controller.rb` to handle ERD display.
>     - Adds `show.html.erb` to display ERD instructions and image.
>     - Ensures "ERD" link only appears if `erd.png` exists in `middleware.rb`.
>   - **Routing**:
>     - Adds route for `/erd` in `engine.rb`.
>   - **Misc**:
>     - Bumps version to `2.0.0` in `version.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fdev_toolbar&utm_source=github&utm_medium=referral)<sup> for 5da6e28e5b45d09b6c201e02484e87911af49d18. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->