### PR TITLE
Add Rails 8 compatibility and bump version to 2.1.0

### DIFF
--- a/dev_toolbar.gemspec
+++ b/dev_toolbar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", "~> 7.0"
+  spec.add_dependency "rails", ">= 7.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/dev_toolbar/version.rb
+++ b/lib/dev_toolbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevToolbar
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
- Updated Rails dependency from ~> 7.0 to >= 7.0
- Bumped version from 2.0.0 to 2.1.0 (minor version for new Rails 8 support)
- This allows compatibility with Rails 7 and Rails 8
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Rails dependency to support versions 7 and 8, and bump gem version to 2.1.0.
> 
>   - **Dependencies**:
>     - Updated Rails dependency in `dev_toolbar.gemspec` from `~> 7.0` to `>= 7.0` to support Rails 8.
>   - **Versioning**:
>     - Bumped version from `2.0.0` to `2.1.0` in `lib/dev_toolbar/version.rb` for new Rails 8 compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fdev_toolbar&utm_source=github&utm_medium=referral)<sup> for 839b49bcd8299f03137aa03618ca336cd50f7bde. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->